### PR TITLE
Fix numpy crashing with ValueError

### DIFF
--- a/src/npy.ml
+++ b/src/npy.ml
@@ -23,7 +23,7 @@ let dtype ~packed_kind =
     | P Bigarray.Int8_signed -> "i1"
     | P Bigarray.Int16_unsigned -> "u2"
     | P Bigarray.Int16_signed -> "i2"
-    | P Bigarray.Char -> "ubyte"
+    | P Bigarray.Char -> "u1"
     | P Bigarray.Complex32 -> "c8" (* 2 32bits float. *)
     | P Bigarray.Complex64 -> "c16" (* 2 64bits float. *)
     | P Bigarray.Int -> failwith "Int is not supported"


### PR DESCRIPTION
If I write char bigarray I get an error while reading file in numpy:

```python
    ~/miniconda3/lib/python3.6/site-packages/numpy/lib/format.py in _read_array_header(fp, version)
    564     except TypeError as e:
    565         msg = "descr is not a valid dtype descriptor: %r"
--> 566         raise ValueError(msg % (d['descr'],))
    567
    568     return d['shape'], d['fortran_order'], dtype

ValueError: descr is not a valid dtype descriptor: '<ubyte'
```